### PR TITLE
tweak PR link

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const messageTemplate = `
 New deployment triggered 🚀
 
 *Service:* {{locals.serviceName}}
-*PR:* <{{context.payload.pull_request.url}}|#{{context.payload.number}}>
+*PR:* <{{context.payload.pull_request.html_url}}|#{{context.payload.number}}>
 *Title:* {{githubToSlack context.payload.pull_request.title}}
 {{#if context.payload.pull_request.body}}
 *Body:*


### PR DESCRIPTION
Looks like in the [GH Pull Request API docs](https://developer.github.com/v3/pulls/#response) `payload.url` is an API link while `payload.html_url` is the web address.